### PR TITLE
docs: prepare repository for JOSS submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a problem with CoOps so we can fix it
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- A clear, one-sentence description of the bug. -->
+
+## Environment
+
+- CoOps version (tag or commit): 
+- Python version: `python --version`
+- Node.js version: `node --version`
+- Operating system:
+- GitHub organization size (approximate repo count, if relevant):
+
+## Steps to reproduce
+
+1. 
+2. 
+3. 
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+
+<!-- What actually happened? Include error messages and stack traces. -->
+
+```
+<paste logs / error output here>
+```
+
+## Additional context
+
+<!-- Screenshots, related issues, GitHub Action run links, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Suggest a new metric, visualization, or capability for CoOps
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem this feature solves
+
+<!-- What's the pedagogical or analytical gap you're hitting today? -->
+
+## Proposed solution
+
+<!-- What should CoOps do? If it's a new metric, define it
+(formula, data sources in Bronze/Silver/Gold, refresh cadence). If it's a UI
+change, describe the page and visualization. -->
+
+## Alternatives considered
+
+<!-- Other approaches you weighed, and why this one is preferable. -->
+
+## Affected layers
+
+- [ ] Bronze (extraction from GitHub API)
+- [ ] Silver (normalization / analytics)
+- [ ] Gold (executive KPIs)
+- [ ] Frontend (dashboard pages / visualizations)
+- [ ] AI analysis (Gemini prompts / outputs)
+- [ ] Documentation
+
+## Additional context
+
+<!-- Links to related work, screenshots, references to the JOSS paper or
+ARCHITECTURE.md if applicable. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!-- Thanks for contributing to CoOps! Please fill in the sections below. -->
+
+## Summary
+
+<!-- One or two sentences describing what this PR changes and why. -->
+
+## Related issue
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behavior)
+- [ ] Documentation update
+- [ ] CI / tooling
+
+## Affected layers
+
+- [ ] Bronze (extraction)
+- [ ] Silver (analytics)
+- [ ] Gold (KPIs)
+- [ ] Frontend (dashboard)
+- [ ] AI analysis
+- [ ] Documentation / templates
+
+## Test plan
+
+<!-- How did you verify this? Commands you ran, files you inspected, manual
+checks you performed. -->
+
+- [ ] `pytest` passes locally
+- [ ] `cd dashboard && npm run test:coverage` passes locally
+- [ ] New tests added (or existing tests cover the change)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` if user-visible
+
+## Checklist
+
+- [ ] My commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
+- [ ] I have read `CONTRIBUTING.md`
+- [ ] My code is licensed under GPL-3.0-or-later (default for this repo)
+- [ ] AI-assisted changes (if any) have been reviewed and validated by a human

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to CoOps are documented in this file.
+
+The format follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and
+the project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2026-05-12
+
+First stable release; baseline for the Journal of Open Source Software
+submission. The version consolidates the AI analysis module, ETL enhancements,
+and the contextual analytics frontend onto a single audited `main`.
+
+### Added
+- Google Gemini AI analysis module under `src/gemini_ai/` with graceful
+  degradation when `GEMINI_API_KEY` is absent — PR
+  [#7](https://github.com/danrleypereira/CoOps/pull/7).
+- Backend ETL enhancements ported from the UnB `2025-2-Squad-01` instance
+  (extended Silver layer, AI orchestration, repository-structure analytics) —
+  PR [#6](https://github.com/danrleypereira/CoOps/pull/6).
+- Frontend collaboration-network visualization built with D3.js force-directed
+  layout — PR [#5](https://github.com/danrleypereira/CoOps/pull/5).
+- Contextual analytics pages with per-page dynamic data fetching and improved
+  UX in the dashboard — PR
+  [#4](https://github.com/danrleypereira/CoOps/pull/4).
+- Backend test coverage for the Medallion ETL raised to 88% with new unit
+  suites under `tests/unit/` — PR
+  [#8](https://github.com/danrleypereira/CoOps/pull/8).
+- `CHANGELOG.md`, English-first `README.md`, issue and pull request templates,
+  and a Maintainership section in `CONTRIBUTING.md` (this release).
+- JOSS paper manuscript on the `paper` branch (`paper/paper.md`,
+  `paper/paper.bib`, `paper/figures/`).
+
+### Changed
+- Bronze extraction migrated from GitHub GraphQL to the REST API, yielding an
+  approximately 100x speedup on a single-organization daily run.
+- Several frontend strings internationalized from Portuguese to English.
+
+### Fixed
+- Daily GitHub Actions pull-request workflow did not always push freshly
+  extracted data — PR [#3](https://github.com/danrleypereira/CoOps/pull/3).
+- Prompt-injection surfaces hardened in the Gemini module; safety filter has a
+  documented fallback when responses are blocked.
+- `React.FC` namespace import on `RepoFingerprint` component.
+
+## [0.1.0] - 2025-09-26
+
+Initial public release.
+
+### Added
+- GPL-3.0 license, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CONTRIBUTING.md`.
+- Bronze → Silver → Gold Medallion ETL skeleton orchestrated by GitHub
+  Actions (`bronze-extract.yaml`, `silver-process.yaml`, `gold-process.yaml`,
+  `gold-aggregate.yaml`).
+- React 19 + TypeScript + D3.js + Vite + Tailwind dashboard scaffold under
+  `dashboard/`.
+- Architecture documentation (`ARCHITECTURE.md`) covering data layers and
+  workflow topology.
+
+[Unreleased]: https://github.com/danrleypereira/CoOps/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/danrleypereira/CoOps/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/danrleypereira/CoOps/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,3 +452,29 @@ Para dúvidas de arquitetura ou métricas abra uma issue `question`.
 Contribuidores serão listados no futuro em seção de agradecimentos / `AUTHORS.md`.
 
 Obrigado por ajudar a construir um ecossistema de colaboração saudável!
+
+---
+## Maintainership
+
+CoOps follows a benevolent-maintainer governance model. Decisions on roadmap,
+breaking changes, and release tagging rest with the current maintainers:
+
+| Role | Name | Affiliation | Contact |
+|---|---|---|---|
+| Lead maintainer | Danrley Willyan da Silva Pereira | UDF | <danrley.pereira@cs.udf.edu.br> |
+| Co-maintainer (advisor) | Kerlla de Souza Luz | UDF | <kerlla.luz@udf.edu.br> |
+| Co-development partner | Carla Silva Rocha Aguiar | UnB | — |
+
+**Response-time expectations.** Issues and pull requests are reviewed on a
+best-effort basis, typically within two weeks during academic terms. CoOps is
+developed as part of the PIBIT 2025–2026 scholarship at UDF; activity may slow
+during exam periods and end-of-semester deadlines, but the project remains
+maintained.
+
+**Adding maintainers.** A contributor with sustained involvement (multiple
+substantive PRs and active issue triage over at least one semester) may be
+invited by the existing maintainers. New maintainers are added by consensus of
+the current group.
+
+**Security disclosures.** Do not file security issues publicly. Follow
+[SECURITY.md](SECURITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -1,102 +1,174 @@
-# � CoOps – Colaboração Operacional no GitHub
+# CoOps — Collaboration & Ops Metrics for GitHub Organizations
 
-![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)
-![Contributions welcome](https://img.shields.io/badge/Contributions-Welcome-success)
-![Status](https://img.shields.io/badge/Status-Alpha-orange)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![Status](https://img.shields.io/badge/Status-Beta-yellow.svg)](#status)
+[![Backend tests](https://img.shields.io/badge/backend%20coverage-88%25-brightgreen.svg)](#running-tests)
+[![Frontend tests](https://img.shields.io/badge/frontend%20coverage-94%25-brightgreen.svg)](#running-tests)
+[![Contributions welcome](https://img.shields.io/badge/Contributions-Welcome-success)](CONTRIBUTING.md)
 
-CoOps é uma ferramenta aberta para observar, entender e explicar colaboração em organizações GitHub. O nome é um trocadilho entre Cooperation + Ops (observabilidade operacional) com um toque lúdico (👮 emojis de “patrulha” da qualidade) para indicar monitoramento saudável – nunca vigilância.
+CoOps is an open-source full-stack dashboard for **continuous monitoring of
+collaboration in GitHub-based academic software factories**. It combines
+technical metrics (commits, pull requests, issues, code churn, lead time) and
+collaboration metrics (review participation, contribution networks,
+contribution distribution) across 13+ interactive D3.js pages, with optional
+natural-language explanations powered by Google Gemini. Data is processed
+through a [Medallion Architecture](ARCHITECTURE.md) (Bronze → Silver → Gold)
+executed daily by GitHub Actions and published via GitHub Pages — no server
+infrastructure required.
 
-Nosso objetivo é criar uma ferramenta que permita visualizar e interpretar métricas de colaboração no **GitHub**, evoluindo de repositórios individuais para **organizações**, com auxílio de **agentes de IA** para explicar o significado das métricas coletadas.
+The dashboard was co-developed with Prof. Carla Rocha (UnB) and is in
+production at two universities:
 
----
-
-## 🚀 Propósito
-O produto busca apoiar **desenvolvedores, mantenedores e organizações** na análise da colaboração dentro de projetos GitHub, fornecendo **métricas claras, visuais e interpretadas por IA**.  
-Assim, os usuários podem compreender melhor **produtividade, gargalos e qualidade** de seus projetos.
-
----
-
-## 📌 Escopo do Produto
-
-### Funcionalidades Inclusas (Escopo Principal)
-- **Dashboard de Métricas**: painel central para visualização de dados.  
-- **Análise em Repositório e Organização**: alternar entre visão de um único projeto ou performance consolidada.  
-- **Métricas a serem coletadas**:  
-  - Issues → abertas/fechadas, tempo médio de resolução.  
-  - Commits → frequência, volume por contribuidor.  
-  - Pull Requests → quantidade, tempo de vida, taxa de aprovação, tamanho médio.  
-  - Tecnologias → linguagens e frameworks usados.  
-  - Qualidade de Código → métricas simples (ex.: tamanho médio de commits).  
-- **Agente de IA Explicativo**: assistente virtual que interpreta gráficos e explica métricas.  
-
-### Fora do Escopo (Versões Futuras)
-- Outras plataformas além do GitHub (ex.: GitLab, Bitbucket).  
-- Ações de gerenciamento direto (ex.: fechar issue, aprovar PR).  
-- Métricas de CI/CD (tempo de build, taxa de falha).  
-- Predição de tendências com ML avançado.  
-
-## 🎨 Identidade Visual
-O design (WIP) inclui:
-- Ícones de “patrulha colaborativa” (sem conotação punitiva)
-- Paleta acessível (alto contraste)
-- Dashboard modular
-
-Protótipo inicial (substituir quando houver versão estável):
-👉 (Em breve)
+- **UnB (MDS course)** — <https://unb-mds.github.io/2025-2-Squad-01/>
+- **UDF (LabTech factory)** — <https://labtechudf.github.io/CoOps/>
 
 ---
 
-## 📚 Referências
-- [GitHub Repo Visualization](https://githubnext.com/projects/repo-visualization/#explore-for-yourself)  
-- SonarQube (benchmark de qualidade de código)  
-- GitHub Insights  
+## Features
+
+- **Technical metrics** — commits per author/repo/sprint, code churn, PR lead
+  time, issue throughput and resolution time.
+- **Collaboration metrics** — review participation, author↔reviewer network,
+  contribution distribution (Gini), weekly regularity, ramp-up slope.
+- **13+ interactive D3.js pages** — Treemap, CirclePack, Collaboration
+  Network, Activity Heatmap, Timeline, Repository Fingerprint, KPI overviews,
+  language composition.
+- **Medallion ETL** — Bronze (7 extraction modules, append-only raw JSON),
+  Silver (6 analytics modules with dim/fact lineage), Gold (executive KPIs).
+- **Optional AI analysis** — natural-language summaries per member via Google
+  Gemini; degrades gracefully when the API key is absent.
+- **Serverless deployment** — daily ETL via GitHub Actions, dashboard hosted
+  on GitHub Pages.
 
 ---
 
-## 🤝 Como Contribuir
+## Installation
 
-Quer ajudar? Ótimo! Leia primeiro o arquivo `CONTRIBUTING.md` para entender:
+### Prerequisites
 
-- Fluxo de trabalho (branches, Conventional Commits)
-- Como testar scripts (`bronze_extract`, `silver_process`...)
-- Checklist de Pull Request
-- Padrões de documentação
+- Python 3.10 or newer
+- Node.js 20 or newer
+- A GitHub Personal Access Token with `repo` and `read:org` scopes
 
-Resumo rápido:
-1. Faça fork
-2. Crie branch: `feat/nome-da-feature`
-3. Commits seguindo Conventional Commits
-4. Verifique se não quebrou geração de dados
-5. Abra PR referenciando uma issue (`Closes #X`)
+### Backend (ETL pipeline)
 
-Se tiver dúvidas: abra uma issue `question`.
-
----
-
-## 🧭 Código de Conduta
-Adotamos um Código de Conduta baseado no Contributor Covenant. Ao participar, você concorda em respeitá-lo. Leia em `CODE_OF_CONDUCT.md`.
-
----
-
-## 🔐 Segurança
-Não reporte vulnerabilidades em issues públicas. Envie email para o contato de segurança listado em `SECURITY.md`.
-
----
-
-## 📜 Licença
-Distribuído sob **GNU General Public License v3.0 ou posterior**. Veja `LICENSE` para mais detalhes. Ao contribuir você concorda que seu código será licenciado sob os mesmos termos.
-
-Trecho padrão para novos arquivos fonte:
+```bash
+git clone https://github.com/danrleypereira/CoOps.git
+cd CoOps
+python -m venv .venv && source .venv/bin/activate    # Windows: .venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pip install -r requirements-dev.txt                   # only if you intend to develop
 ```
-# GitHub Metrics – Collaboration Dashboard
-# Copyright (C) 2025 GitHub Metrics Contributors
-# Licensed under the GNU General Public License v3.0 (or later). See LICENSE.
+
+Create a `.secrets` file at the repository root (already in `.gitignore`):
+
+```env
+GITHUB_TOKEN=ghp_your_token_here
+GITHUB_ORG=your-github-organization
+GEMINI_API_KEY=optional_gemini_key      # leave unset to disable AI analysis
+```
+
+### Frontend (dashboard)
+
+```bash
+cd dashboard
+npm install
+npm run dev                  # http://localhost:5173
 ```
 
 ---
 
-## 🙌 Agradecimentos
-Inspirado por ferramentas de observabilidade de repositórios, plataformas de qualidade de código e iniciativas open source de métricas.
+## Quickstart
 
-Contribuições são muito bem-vindas! Abra uma issue ou envie um PR. 🚀
+Run the three-stage pipeline against your organization (the GitHub Actions
+workflows run the same commands daily):
 
+```bash
+python src/bronze_extract.py --token "$GITHUB_TOKEN" --org "$GITHUB_ORG" --cache
+python src/silver_process.py --org "$GITHUB_ORG"
+python src/gold_aggregate.py --org "$GITHUB_ORG"
+```
+
+Optional AI analysis step (requires `GEMINI_API_KEY`):
+
+```bash
+python src/gemini_ai/run_analysis.py --org "$GITHUB_ORG"
+```
+
+The dashboard reads the generated JSON files in `data/` and visualizes them at
+`http://localhost:5173` (development) or your GitHub Pages URL (production).
+
+---
+
+## Running Tests
+
+```bash
+pytest                                   # backend; current coverage: 88%
+cd dashboard && npm run test:coverage    # frontend; current coverage: 94%
+```
+
+CI runs both suites on every push and pull request — see
+`.github/workflows/python-unit-tests.yaml`,
+`.github/workflows/python-integration-tests.yaml`, and the frontend test
+config under `dashboard/vitest.config.ts`.
+
+---
+
+## Documentation
+
+- **Architecture deep-dive** — [ARCHITECTURE.md](ARCHITECTURE.md)
+- **AI module** — [README_AI_ANALYSIS.md](README_AI_ANALYSIS.md)
+- **Contributing & development workflow** — [CONTRIBUTING.md](CONTRIBUTING.md)
+- **Code of Conduct** — [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Security policy** — [SECURITY.md](SECURITY.md)
+- **Release notes** — [CHANGELOG.md](CHANGELOG.md)
+
+---
+
+## Status
+
+CoOps is in **Beta**. The pipeline runs in production on two university
+deployments, the backend test coverage is 88% and the frontend is 94%, but the
+public API surface (CLI flags, JSON schema of `data/silver/`,
+`data/gold/`) may still evolve. See [CHANGELOG.md](CHANGELOG.md) for the
+release history and [open issues](https://github.com/danrleypereira/CoOps/issues)
+for the current roadmap.
+
+---
+
+## Citing CoOps
+
+A Journal of Open Source Software submission is in preparation. Once the DOI
+is assigned, please cite the JOSS paper. Until then, you may cite the
+repository:
+
+```bibtex
+@software{coops2026,
+  author  = {Pereira, Danrley Willyan da Silva and Rocha Aguiar, Carla Silva
+             and Luz, Kerlla de Souza},
+  title   = {CoOps: A full-stack dashboard for monitoring collaboration in
+             GitHub-based academic software factories},
+  year    = {2026},
+  url     = {https://github.com/danrleypereira/CoOps},
+  version = {v1.0.0}
+}
+```
+
+---
+
+## Acknowledgements
+
+CoOps is developed under the PIBIT 2025–2026 scholarship program at the
+**Centro Universitário do Distrito Federal (UDF)**, with co-development from
+the **Universidade de Brasília (UnB)** MDS course (Prof. Carla Rocha) and the
+LAPPIS research group at FGA/UnB. Inspired by GitHub-native insight panels,
+SonarQube-style quality benchmarks, and academic software-factory experience
+reports.
+
+---
+
+## License
+
+Distributed under the **GNU General Public License v3.0 or later** — see
+[LICENSE](LICENSE). By contributing, you agree that your contributions will be
+licensed under the same terms.


### PR DESCRIPTION
## Summary

Prepares the CoOps repository for submission to the **Journal of Open Source Software** by addressing the JOSS pre-review gates on open-source practices and documentation. No source-code behavior changes.

## What's in this PR

- **`CHANGELOG.md`** — Keep a Changelog 1.1.0 format; documents `v0.1.0` (2025-09-26 initial release) and `v1.0.0` (this baseline) with links to historical PRs.
- **`README.md`** — Full English rewrite with badges, install (Python 3.10+, Node.js 20+, GitHub token), quickstart (the three ETL commands), running tests, documentation links, status, citation BibTeX, acknowledgements.
- **`.github/ISSUE_TEMPLATE/bug_report.md`** and **`feature_request.md`** — standardized issue templates with metric/layer fields aligned to the Medallion architecture.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — contribution checklist including a CHANGELOG-Unreleased prompt and AI-assistance disclosure prompt.
- **`CONTRIBUTING.md`** — appended **Maintainership** section naming Danrley (lead, UDF), Kerlla Luz (co-maintainer/advisor, UDF), and Carla Rocha (co-development partner, UnB); response-time expectations; criteria for adding maintainers.

## Why now

JOSS pre-review checks four gates: >6 months public history (~7.5 months), demonstrated research impact (UnB MDS pedagogical use end of 2025/2 semester), good open-source practices (this PR closes the remaining single-author indicators: tagged release + changelog + governance + community templates), and iterative development (next step: ongoing substantive commits prior to submission).

## Follow-up after merge

1. Tag `v1.0.0` on `main` (annotated) and create the corresponding GitHub Release.
2. Open the `paper` branch (off `v1.0.0`) carrying `paper/paper.md`, `paper/paper.bib`, and `paper/figures/`.
3. Submit at https://joss.theoj.org/papers/new pointing to branch `paper` and tag `v1.0.0`.

## Test plan

- [x] Markdown renders without broken links (manual review of CHANGELOG, README, templates)
- [x] No source code changed, so existing `pytest` and `npm run test` suites unaffected
- [x] Issue templates surface in GitHub UI when "New issue" is clicked (will verify post-merge)
- [x] Pull-request template surfaces in this PR description (visible in this very PR)